### PR TITLE
Modernize automation YAML to new trigger/action syntax

### DIFF
--- a/automations/areas/bathroom/room_mode_staleness.yaml
+++ b/automations/areas/bathroom/room_mode_staleness.yaml
@@ -5,7 +5,7 @@ mode: single
 id: 62333f07-0bd3-442f-b180-d43667ba9462
 
 trigger:
-  - platform: time_pattern
+  - trigger: time_pattern
     minutes: "/30"
 
 action:

--- a/automations/areas/bedroom_small/blinds.yaml
+++ b/automations/areas/bedroom_small/blinds.yaml
@@ -34,7 +34,7 @@ action:
             - input_select.smallbedroom_current_cover_scene
           state: "closed"
       sequence:
-        - service: scene.turn_on
+        - action: scene.turn_on
           target:
             entity_id: scene.smallbedroom_cover_open
 
@@ -53,7 +53,7 @@ action:
             - input_select.smallbedroom_current_cover_scene
           state: "open"
       sequence:
-        - service: scene.turn_on
+        - action: scene.turn_on
           target:
             entity_id: scene.smallbedroom_cover_closed
 
@@ -69,7 +69,7 @@ action:
                 - binary_sensor.is_hot_day
               state: "on"
       sequence:
-        - service: scene.turn_on
+        - action: scene.turn_on
           target:
             entity_id: scene.smallbedroom_cover_closed
 

--- a/automations/areas/bedroom_small/climate.yaml
+++ b/automations/areas/bedroom_small/climate.yaml
@@ -30,21 +30,21 @@ variables:
     - &turn_on
       <<: *target
       alias: "Turn on heating"
-      service: climate.set_hvac_mode
+      action: climate.set_hvac_mode
       data:
         hvac_mode: "heat"
 
     - &turn_down
       <<: *target
       alias: "Turn down small bedroom climate"
-      service: climate.set_temperature
+      action: climate.set_temperature
       data:
         temperature: 15.0
 
     - &turn_up
       <<: *target
       alias: "Turn down small bedroom climate"
-      service: climate.set_temperature
+      action: climate.set_temperature
       data:
         temperature: 16.0
 

--- a/automations/areas/bedroom_small/lights.yaml
+++ b/automations/areas/bedroom_small/lights.yaml
@@ -7,7 +7,7 @@ max_exceeded: silent
 id: ca30804b-41af-4ca6-8d00-869978d17810
 
 trigger:
-  - platform: event
+  - trigger: event
     event_type: zwave_js_value_notification
     event_data:
       device_id: d2facfeac2ccc4f9eb4da6139c01da41
@@ -31,7 +31,7 @@ action:
                   state: "Slaap"
 
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   target:
                     entity_id: light.fibaro_small_bedroom
                   data:
@@ -43,19 +43,19 @@ action:
                     - binary_sensor.livingroom_is_dark
                   state: "on"
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   target:
                     entity_id: light.fibaro_small_bedroom
                   data:
                     brightness_pct: 70
 
           default:
-            - service: light.turn_on
+            - action: light.turn_on
               target:
                 entity_id: light.fibaro_small_bedroom
               data:
                 brightness_pct: 70
   default:
-    - service: light.turn_off
+    - action: light.turn_off
       target:
         entity_id: light.fibaro_small_bedroom

--- a/automations/areas/hall_downstairs/climate.yaml
+++ b/automations/areas/hall_downstairs/climate.yaml
@@ -5,13 +5,13 @@ id: 9184d186-def2-431e-af58-1aabe0bce9a8
 mode: queued
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.everyone_left_home
       - binary_sensor.house_mode_everyone_at_home_working
@@ -19,7 +19,7 @@ trigger:
       - input_boolean.setting_guest_mode
     from: ~
 
-  - platform: time
+  - trigger: time
     at: "21:00:00"
 
 variables:
@@ -31,21 +31,21 @@ variables:
     - &turn_on
       <<: *target
       alias: "Turn on heating"
-      service: climate.set_hvac_mode
+      action: climate.set_hvac_mode
       data:
         hvac_mode: "heat"
 
     - &turn_down
       <<: *target
       alias: "Turn downcclimate"
-      service: climate.set_temperature
+      action: climate.set_temperature
       data:
         temperature: 15.0
 
     - &turn_up
       <<: *target
       alias: "Turn down climate"
-      service: climate.set_temperature
+      action: climate.set_temperature
       data:
         temperature: 19.0
 

--- a/automations/areas/hall_upstairs/room_mode.yaml
+++ b/automations/areas/hall_upstairs/room_mode.yaml
@@ -5,7 +5,7 @@ mode: queued
 id: a45985eb-5a55-448f-8cbd-d2e712a281ab
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id:
       - input_select.master_bedroom_room_mode
 

--- a/automations/areas/hall_upstairs/room_mode_staleness.yaml
+++ b/automations/areas/hall_upstairs/room_mode_staleness.yaml
@@ -5,7 +5,7 @@ mode: single
 id: 6a211846-c272-49aa-b32c-11a03100ab1b
 
 trigger:
-  - platform: time_pattern
+  - trigger: time_pattern
     minutes: "/30"
 
 action:

--- a/automations/areas/kitchen/blinds.yaml
+++ b/automations/areas/kitchen/blinds.yaml
@@ -9,42 +9,42 @@ max_exceeded: silent
 id: 38622ce4-5865-45c4-8cb8-7b3b54801280
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id:
       - input_select.livingroom_room_mode
 
-  - platform: state
+  - trigger: state
     entity_id:
       - input_boolean.setting_manual_blinds
       - input_boolean.kitchen_cover_manual_control
 
-  - platform: numeric_state
+  - trigger: numeric_state
     entity_id:
       - sensor.sun_adjusted_elevation
     below: 0
 
-  - platform: numeric_state
+  - trigger: numeric_state
     entity_id:
       - sensor.sun_adjusted_elevation
     above: 4
 
-  - platform: time
+  - trigger: time
     at: "20:45:00"
     id: "time_close_kitchen"
 
-  - platform: state
+  - trigger: state
     entity_id:
       - scene.kitchen_cover_halfclosed
       - scene.kitchen_cover_halfopen
     id: kitchen_blinds
 
-  - platform: time
+  - trigger: time
     at: "03:00:00"
     id: "reset"
 
@@ -52,25 +52,25 @@ variables:
   anchors:
     - &halfclosed
       alias: "Close the blinds halfway"
-      service: scene.turn_on
+      action: scene.turn_on
       target:
         entity_id: scene.kitchen_cover_halfclosed
 
     - &halfopen
       alias: "Open the blinds halfway"
-      service: scene.turn_on
+      action: scene.turn_on
       target:
         entity_id: scene.kitchen_cover_halfopen
 
     - &manual_control_on
       alias: "Set manual control to on, so the blinds stay closed"
-      service: input_boolean.turn_on
+      action: input_boolean.turn_on
       target:
         entity_id: input_boolean.kitchen_cover_manual_control
 
     - &manual_control_off
       alias: "Reset manual control to on, so the blinds are automated again"
-      service: input_boolean.turn_off
+      action: input_boolean.turn_off
       target:
         entity_id: input_boolean.kitchen_cover_manual_control
 

--- a/automations/areas/kitchen/climate.yaml
+++ b/automations/areas/kitchen/climate.yaml
@@ -5,13 +5,13 @@ id: 7b9f8a4f-a43f-4e1f-b28e-fdefc8f113bb
 mode: queued
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id:
       - input_select.livingroom_room_mode
       - binary_sensor.everyone_left_home
@@ -19,12 +19,12 @@ trigger:
       - input_boolean.setting_guest_mode
     from: ~
 
-  - platform: state
+  - trigger: state
     entity_id: binary_sensor.garden_door_open
     for:
       seconds: 10
 
-  - platform: time
+  - trigger: time
     at:
       - "21:00:00"
       - "18:00:00"
@@ -38,28 +38,28 @@ variables:
     - &turn_on
       <<: *target
       alias: "Turn on heating"
-      service: climate.set_hvac_mode
+      action: climate.set_hvac_mode
       data:
         hvac_mode: "heat"
 
     - &turn_down
       <<: *target
       alias: "Turn down kitchen climate"
-      service: climate.set_temperature
+      action: climate.set_temperature
       data:
         temperature: 15.0
 
     - &turn_up
       <<: *target
       alias: "Turn down kitchen climate"
-      service: climate.set_temperature
+      action: climate.set_temperature
       data:
         temperature: 20.0
 
     - &turn_low
       <<: *target
       alias: "Turn down kitchen climate"
-      service: climate.set_temperature
+      action: climate.set_temperature
       data:
         temperature: 19.0
 

--- a/automations/areas/kitchen/cooking_mode.yaml
+++ b/automations/areas/kitchen/cooking_mode.yaml
@@ -5,19 +5,19 @@ mode: queued
 id: b9982ead-5320-48cb-8b44-b7df02698f32
 
 trigger:
-  - platform: event
+  - trigger: event
     event_type: "zha_event"
     event_data:
       device_id: "b2bbc724616dc6968e36850327263ed8"
       command: "single"
 
-  - platform: event
+  - trigger: event
     event_type: "zha_event"
     event_data:
       device_id: "b2bbc724616dc6968e36850327263ed8"
       command: "double"
 
 action:
-  - service: input_boolean.toggle
+  - action: input_boolean.toggle
     target:
       entity_id: input_boolean.house_mode_cooking

--- a/automations/areas/kitchen/lights.yaml
+++ b/automations/areas/kitchen/lights.yaml
@@ -7,39 +7,39 @@ trace:
   stored_traces: 25
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id: binary_sensor.presence_kitchen
     to: "on"
 
-  - platform: state
+  - trigger: state
     entity_id: binary_sensor.presence_kitchen
     to: "off"
     for:
       seconds: 50
 
-  - platform: state
+  - trigger: state
     entity_id: binary_sensor.presence_kitchen
     to: "off"
     for:
       seconds: 5
     id: "presence_off_5s"
 
-  - platform: state
+  - trigger: state
     entity_id: input_select.current_light_schedule
     id: light_schedule_change
 
-  - platform: state
+  - trigger: state
     entity_id: media_player.apple_tv
     to: "playing"
     id: "apple_tv_playing"
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.kitchen_is_dark
       - input_boolean.house_mode_cooking
@@ -49,13 +49,13 @@ variables:
   anchors:
     - &turn_on
       alias: "Turn on the lights"
-      service: scene.turn_on
+      action: scene.turn_on
       data:
         transition: 1
 
     - &turn_off
       alias: "Turn the lights off"
-      service: light.turn_off
+      action: light.turn_off
       data:
         entity_id: light.led_kitchen
         transition: 3

--- a/automations/areas/livingroom/blinds_gardendoor.yaml
+++ b/automations/areas/livingroom/blinds_gardendoor.yaml
@@ -14,13 +14,13 @@ trace:
   stored_traces: 25
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.sun_should_close_south_blinds
       - input_boolean.setting_manual_blinds
@@ -34,46 +34,46 @@ trigger:
       - "off"
       - "on"
 
-  - platform: state
+  - trigger: state
     entity_id:
       - input_select.livingroom_room_mode
 
-  - platform: numeric_state
+  - trigger: numeric_state
     entity_id:
       - sensor.sun_adjusted_elevation
     below: -9
 
-  - platform: state
+  - trigger: state
     entity_id: sensor.gw3000a_solar_lux
     to: "0"
 
-  - platform: numeric_state
+  - trigger: numeric_state
     entity_id:
       - sensor.sun_adjusted_elevation
     above: 4
 
-  - platform: state
+  - trigger: state
     entity_id: input_button.gardendoor_nspanel
     id: "garden_door_switch"
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.garden_door_open
     to: "on"
     id: "garden_door_open"
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.garden_door_open
     to: "off"
 
-  - platform: state
+  - trigger: state
     entity_id: media_player.living_room_android
     to: "off"
     for:
       minutes: 1
 
-  - platform: state
+  - trigger: state
     entity_id:
       - scene.gardendoor_cover_closed
       - scene.gardendoor_cover_halfclosed
@@ -82,7 +82,7 @@ trigger:
       - scene.gardendoor_cover_sun
     id: gardendoor_blinds
 
-  - platform: time
+  - trigger: time
     at: "00:03:00"
     id: "reset"
 
@@ -90,41 +90,41 @@ variables:
   anchors:
     - &cover_closed
       alias: "Close the blinds"
-      service: scene.turn_on
+      action: scene.turn_on
       target:
         entity_id:
           - scene.gardendoor_cover_closed
 
     - &cover_half_closed
       alias: "Close the blinds halfway"
-      service: scene.turn_on
+      action: scene.turn_on
       target:
         entity_id:
           - scene.gardendoor_cover_halfclosed
 
     - &cover_half_open
       alias: "Open the blinds half way"
-      service: scene.turn_on
+      action: scene.turn_on
       target:
         entity_id:
           - scene.gardendoor_cover_halfopen
 
     - &cover_sun
       alias: "Block out the sun on a hot day"
-      service: scene.turn_on
+      action: scene.turn_on
       target:
         entity_id:
           - scene.gardendoor_cover_sun
 
     - &manual_control_on
       alias: "Set manual control to on, so the blinds stay closed"
-      service: input_boolean.turn_on
+      action: input_boolean.turn_on
       target:
         entity_id: input_boolean.livingroom_cover_manual_control
 
     - &manual_control_off
       alias: "Reset manual control, so the blinds stay closed"
-      service: input_boolean.turn_off
+      action: input_boolean.turn_off
       target:
         entity_id: input_boolean.livingroom_cover_manual_control
 

--- a/automations/areas/livingroom/blinds_livingroom.yaml
+++ b/automations/areas/livingroom/blinds_livingroom.yaml
@@ -11,13 +11,13 @@ max_exceeded: silent
 id: 3b9ac19f-e963-4f1d-9ef8-a6fd0c4ebc5c
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.sun_should_close_south_blinds
       - input_boolean.setting_manual_blinds
@@ -31,25 +31,25 @@ trigger:
       - "off"
       - "on"
 
-  - platform: state
+  - trigger: state
     entity_id:
       - input_select.livingroom_room_mode
 
-  - platform: numeric_state
+  - trigger: numeric_state
     entity_id:
       - sensor.sun_adjusted_elevation
     below: -9
 
-  - platform: state
+  - trigger: state
     entity_id: sensor.gw3000a_solar_lux
     to: "0"
 
-  - platform: numeric_state
+  - trigger: numeric_state
     entity_id:
       - sensor.sun_adjusted_elevation
     above: 4
 
-  - platform: state
+  - trigger: state
     entity_id: media_player.apple_tv
     to:
       - idle
@@ -58,7 +58,7 @@ trigger:
     for:
       minutes: 8
 
-  - platform: state
+  - trigger: state
     entity_id:
       - scene.livingroom_cover_closed
       - scene.livingroom_cover_halfclosed
@@ -67,7 +67,7 @@ trigger:
       - scene.livingroom_cover_ventilatingnight
     id: livingroom_blinds
 
-  - platform: time
+  - trigger: time
     at: "03:00:00"
     id: "reset"
 
@@ -75,34 +75,34 @@ variables:
   anchors:
     - &cover_closed
       alias: "Close the blinds"
-      service: scene.turn_on
+      action: scene.turn_on
       target:
         entity_id:
           - scene.livingroom_cover_closed
 
     - &cover_half_closed
       alias: "Close the blinds halfway"
-      service: scene.turn_on
+      action: scene.turn_on
       target:
         entity_id:
           - scene.livingroom_cover_halfclosed
 
     - &cover_half_open
       alias: "Open the blinds half way"
-      service: scene.turn_on
+      action: scene.turn_on
       target:
         entity_id:
           - scene.livingroom_cover_halfopen
 
     - &manual_control_on
       alias: "Set manual control to on, so the blinds stay closed"
-      service: input_boolean.turn_on
+      action: input_boolean.turn_on
       target:
         entity_id: input_boolean.livingroom_cover_manual_control
 
     - &manual_control_off
       alias: "Reset manual control, so the blinds stay closed"
-      service: input_boolean.turn_off
+      action: input_boolean.turn_off
       target:
         entity_id: input_boolean.livingroom_cover_manual_control
 

--- a/automations/areas/livingroom/christmas_tree.yaml
+++ b/automations/areas/livingroom/christmas_tree.yaml
@@ -5,21 +5,21 @@ mode: queued
 id: 74468068-43d1-40a0-8eec-822a4235adfc
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: time
+  - trigger: time
     at: "20:00:00"
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.presence_livingroom
     to: "on"
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.presence_livingroom
     to: "off"
@@ -40,13 +40,13 @@ variables:
 
     - &turn_off
       alias: "Turn the christmas tree off"
-      service: light.turn_off
+      action: light.turn_off
       target:
         entity_id: light.christmas_tree
 
     - &turn_on
       alias: "Turn on the lights on"
-      service: scene.turn_on
+      action: scene.turn_on
       data:
         transition: 2
 

--- a/automations/areas/livingroom/climate.yaml
+++ b/automations/areas/livingroom/climate.yaml
@@ -5,13 +5,13 @@ id: 1c012736-f49b-4da5-95f0-dd363369c64e
 mode: queued
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id:
       - input_select.livingroom_room_mode
       - binary_sensor.everyone_left_home
@@ -19,12 +19,12 @@ trigger:
       - input_boolean.setting_guest_mode
     from: ~
 
-  - platform: state
+  - trigger: state
     entity_id: binary_sensor.garden_door_open
     for:
       seconds: 10
 
-  - platform: time
+  - trigger: time
     at: "21:00:00"
 
 variables:
@@ -38,21 +38,21 @@ variables:
     - &turn_on
       <<: *target
       alias: "Turn on heating"
-      service: climate.set_hvac_mode
+      action: climate.set_hvac_mode
       data:
         hvac_mode: "heat"
 
     - &turn_down
       <<: *target
       alias: "Turn down living room climate"
-      service: climate.set_temperature
+      action: climate.set_temperature
       data:
         temperature: 15.0
 
     - &turn_up
       <<: *target
       alias: "Turn down living room climate"
-      service: climate.set_temperature
+      action: climate.set_temperature
       data:
         temperature: 20.0
 

--- a/automations/areas/livingroom/lights.yaml
+++ b/automations/areas/livingroom/lights.yaml
@@ -7,17 +7,17 @@ trace:
   stored_traces: 25
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id:
       - input_boolean.setting_manual_lights
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.livingroom_is_dark
     from: ~
@@ -25,34 +25,34 @@ trigger:
       seconds: 2
     id: light_dark_change
 
-  - platform: state
+  - trigger: state
     entity_id: input_select.current_light_schedule
     id: light_schedule_change
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.livingroom_is_media_playing
     for:
       seconds: 10
 
-  - platform: state
+  - trigger: state
     entity_id:
       - media_player.living_room_android
     to: "off"
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.presence_livingroom
     to: "on"
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.presence_livingroom
     to: "off"
     for:
       minutes: 10
 
-  - platform: time
+  - trigger: time
     at: "00:03:00"
     id: "reset"
 
@@ -94,7 +94,7 @@ variables:
 
     - &turn_off
       alias: "Turn the lights off"
-      service: light.turn_off
+      action: light.turn_off
       target:
         entity_id:
           - light.livingroom
@@ -106,7 +106,7 @@ variables:
 
     - &turn_on
       alias: "Turn on the lights"
-      service: scene.turn_on
+      action: scene.turn_on
       data:
         transition: 2
 

--- a/automations/areas/livingroom/nspanel/nspanel.yaml
+++ b/automations/areas/livingroom/nspanel/nspanel.yaml
@@ -5,7 +5,7 @@ alias: areas_livingroom_nspanel
 id: 5b09a806-78d6-40bf-b463-06144cb5d2dd
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id:
       - media_player.mass_sonos_kitchen
 
@@ -14,7 +14,7 @@ variables:
   anchors:
     - &go_to_home_page
       alias: "Navigate to the home page"
-      service: browser_mod.navigate
+      action: browser_mod.navigate
       target:
         device_id: 3592045e4bb5ae83ef15433835cd13d2
       data:
@@ -22,7 +22,7 @@ variables:
 
     - &go_to_music_page
       alias: "Navigate to the music page"
-      service: browser_mod.navigate
+      action: browser_mod.navigate
       target:
         device_id: 3592045e4bb5ae83ef15433835cd13d2
       data:

--- a/automations/areas/livingroom/nspanel/nspanel_brightness.yaml
+++ b/automations/areas/livingroom/nspanel/nspanel_brightness.yaml
@@ -5,13 +5,13 @@ alias: areas_livingroom_nspanel_brightness
 id: e6d6d7bc-5ad6-493a-878c-9209248e6ee3
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.livingroom_is_dark
       - input_select.livingroom_current_lights_scene
@@ -20,15 +20,15 @@ trigger:
 variables:
   anchors:
     - &set_brightness
-      service: number.set_value
+      action: number.set_value
       entity_id: number.nspanel_screen_brightness
 
     - &turn_off
-      service: switch.turn_on
+      action: switch.turn_on
       entity_id: switch.nspanel_screensaver
 
     - &turn_on
-      service: switch.turn_off
+      action: switch.turn_off
       entity_id: switch.nspanel_screensaver
 
 action:

--- a/automations/areas/livingroom/nspanel/nspanel_doorbell.yaml
+++ b/automations/areas/livingroom/nspanel/nspanel_doorbell.yaml
@@ -6,13 +6,13 @@ alias: areas_livingroom_nspanel_doorbell
 id: 966923a2-3965-439c-a0e7-730e8d742daa
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.g4_doorbell_doorbell
     to: "on"
 
 action:
-  - service: media_player.play_media
+  - action: media_player.play_media
     data:
       media_content_id: !secret doorbell_chime_url
       media_content_type: audio/mp3

--- a/automations/areas/livingroom/nspanel/nspanel_reconnect.yaml
+++ b/automations/areas/livingroom/nspanel/nspanel_reconnect.yaml
@@ -5,11 +5,11 @@ alias: areas_livingroom_nspanel_reconnect
 id: f3118cb2-221d-49e2-93de-08617e3efeed
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id:
       - light.npanelfkm_screen
     to: "unavailable"
 
 action:
-  - service: button.press
+  - action: button.press
     entity_id: button.rk3326_restart_browser

--- a/automations/areas/livingroom/nspanel/nspanel_theme.yaml
+++ b/automations/areas/livingroom/nspanel/nspanel_theme.yaml
@@ -5,13 +5,13 @@ alias: areas_livingroom_nspanel_theme
 id: c7e57828-e414-4247-b354-e17728544e5b
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.livingroom_is_dark
 
@@ -24,7 +24,7 @@ action:
             state: "on"
         sequence:
           - alias: "Turn on dark mode"
-            service: browser_mod.set_theme
+            action: browser_mod.set_theme
             target:
               device_id: 3592045e4bb5ae83ef15433835cd13d2
             data:
@@ -33,7 +33,7 @@ action:
 
     default:
       - alias: "Turn on light mode"
-        service: browser_mod.set_theme
+        action: browser_mod.set_theme
         target:
           device_id: 3592045e4bb5ae83ef15433835cd13d2
         data:

--- a/automations/areas/livingroom/room_mode.yaml
+++ b/automations/areas/livingroom/room_mode.yaml
@@ -5,7 +5,7 @@ mode: queued
 id: 775a9a3e-558d-4030-97a9-fe9f4eb24c99
 
 trigger:
-  - platform: state
+  - trigger: state
     id: "net_wakker_40m"
     entity_id:
       - input_select.livingroom_room_mode
@@ -13,7 +13,7 @@ trigger:
     for:
       minutes: 40
 
-  - platform: state
+  - trigger: state
     id: "presence_off_1h"
     entity_id:
       - binary_sensor.presence_livingroom
@@ -21,25 +21,25 @@ trigger:
     for:
       minutes: 60
 
-  - platform: state
+  - trigger: state
     id: "presence_detected"
     entity_id:
       - binary_sensor.presence_livingroom
     to: "on"
 
-  - platform: state
+  - trigger: state
     id: "front_door_open"
     entity_id: binary_sensor.presence_front_door
     to: "on"
 
-  - platform: time
+  - trigger: time
     id: "reset_holiday"
     at: "10:00:00"
 
 variables:
   anchors:
     - &select_mode
-      service: input_select.select_option
+      action: input_select.select_option
       entity_id: input_select.livingroom_room_mode
 
     - &is_sleep_mode_selected
@@ -69,7 +69,7 @@ action:
           - *is_sleep_mode_selected
         sequence:
           - wait_for_trigger:
-              - platform: state
+              - trigger: state
                 entity_id:
                   - binary_sensor.presence_livingroom
                 to: "on"

--- a/automations/areas/livingroom/room_mode_staleness.yaml
+++ b/automations/areas/livingroom/room_mode_staleness.yaml
@@ -5,7 +5,7 @@ mode: single
 id: 149004a9-a1a6-446d-b749-4d15af721b2c
 
 trigger:
-  - platform: time_pattern
+  - trigger: time_pattern
     minutes: "/30"
 
 variables:

--- a/automations/areas/livingroom/vacuum.yaml
+++ b/automations/areas/livingroom/vacuum.yaml
@@ -20,7 +20,7 @@ variables:
         entity_id: button.norby_deep_clean
 
 trigger:
-  - platform: time
+  - trigger: time
     at: "01:00:00"
 
 action:

--- a/automations/areas/mancave/room_mode.yaml
+++ b/automations/areas/mancave/room_mode.yaml
@@ -5,7 +5,7 @@ mode: queued
 id: 434c6fd5-646d-4ee3-85ff-3c162d246ff8
 
 trigger:
-  - platform: state
+  - trigger: state
     id: "net_wakker_40m"
     entity_id:
       - input_select.mancave_room_mode
@@ -16,7 +16,7 @@ trigger:
 variables:
   anchors:
     - &select_mode
-      service: input_select.select_option
+      action: input_select.select_option
       entity_id: input_select.mancave_room_mode
 
 action:

--- a/automations/areas/mancave/room_mode_staleness.yaml
+++ b/automations/areas/mancave/room_mode_staleness.yaml
@@ -5,7 +5,7 @@ mode: single
 id: 89c8727d-ab33-45f0-aaf3-7efa6a5147f5
 
 trigger:
-  - platform: time_pattern
+  - trigger: time_pattern
     minutes: "/30"
 
 variables:

--- a/automations/areas/mancave/sonos_night_sound.yaml
+++ b/automations/areas/mancave/sonos_night_sound.yaml
@@ -5,29 +5,29 @@ mode: queued
 id: dda0cfa4-664f-43ac-9afe-c71d009f3abf
 
 trigger:
-  - platform: time
+  - trigger: time
     at: "19:00:00"
 
-  - platform: state
+  - trigger: state
     entity_id: binary_sensor.house_mode_someone_asleep
 
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
 variables:
   anchors:
     - &night_sound_on
       alias: "Turn night sound on"
-      service: switch.turn_on
+      action: switch.turn_on
       target:
         entity_id: switch.sonos_mancave_night_sound
 
     - &night_sound_off
       alias: "Turn night sound off"
-      service: switch.turn_off
+      action: switch.turn_off
       target:
         entity_id: switch.sonos_mancave_night_sound
 

--- a/automations/areas/master_bedroom/climate.yaml
+++ b/automations/areas/master_bedroom/climate.yaml
@@ -5,20 +5,20 @@ id: 0a71bc6d-3ba2-45b3-af71-5b8489f1665e
 mode: queued
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id:
       - input_select.master_bedroom_room_mode
       - binary_sensor.everyone_left_home
       - binary_sensor.house_mode_everyone_at_home_working
     from: ~
 
-  - platform: time
+  - trigger: time
     at: "21:00:00"
 
 variables:
@@ -30,21 +30,21 @@ variables:
     - &turn_on
       <<: *target
       alias: "Turn on heating"
-      service: climate.set_hvac_mode
+      action: climate.set_hvac_mode
       data:
         hvac_mode: "heat"
 
     - &turn_down
       <<: *target
       alias: "Turn down master bedroom climate"
-      service: climate.set_temperature
+      action: climate.set_temperature
       data:
         temperature: 15.0
 
     - &turn_up
       <<: *target
       alias: "Turn down master bedroom climate"
-      service: climate.set_temperature
+      action: climate.set_temperature
       data:
         temperature: 17.0
 

--- a/automations/areas/master_bedroom/room_mode_staleness.yaml
+++ b/automations/areas/master_bedroom/room_mode_staleness.yaml
@@ -5,7 +5,7 @@ mode: single
 id: 3be82abc-8ff2-41e6-b103-ab4e59bc1304
 
 trigger:
-  - platform: time_pattern
+  - trigger: time_pattern
     minutes: "/30"
 
 variables:

--- a/automations/house/doorbell_chime.yaml
+++ b/automations/house/doorbell_chime.yaml
@@ -4,11 +4,11 @@ alias: house_doorbell_chime
 id: b5bf8e66-aa47-4dcd-b827-f4f4391ec840
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
-  - platform: state
+  - trigger: state
     entity_id:
       - binary_sensor.house_mode_someone_asleep
       - schedule.silent_hours
@@ -29,12 +29,12 @@ action:
                 state: "on"
         sequence:
           - alias: "Turn the doorbell off"
-            service: switch.turn_off
+            action: switch.turn_off
             target:
               entity_id: switch.doorbell_chime
 
     default:
       - alias: "Turn the doorbell on"
-        service: switch.turn_on
+        action: switch.turn_on
         target:
           entity_id: switch.doorbell_chime

--- a/automations/house/guest_mode.yaml
+++ b/automations/house/guest_mode.yaml
@@ -10,24 +10,24 @@ variables:
   anchors:
     - &turn_on
       alias: "Turn guest mode on"
-      service: input_boolean.turn_on
+      action: input_boolean.turn_on
       data:
         entity_id: input_boolean.setting_guest_mode
 
     - &turn_off
       alias: "Turn guest mode off"
-      service: input_boolean.turn_off
+      action: input_boolean.turn_off
       data:
         entity_id: input_boolean.setting_guest_mode
 
 trigger:
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
-  - platform: state
+  - trigger: state
     entity_id:
       - group.frequent_guests
       - binary_sensor.everyone_left_home

--- a/automations/presence/away.yaml
+++ b/automations/presence/away.yaml
@@ -5,20 +5,20 @@ mode: single
 id: 3fb50eae-6c01-4048-81af-429f20854158
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id: input_select.marvin_status_dropdown
     to: "Net weg"
     for:
       minutes: 10
-  - platform: state
+  - trigger: state
     entity_id: input_select.laura_status_dropdown
     to: "Net weg"
     for:
       minutes: 10
 
 action:
-  - service: input_select.select_option
-    data_template:
+  - action: input_select.select_option
+    data:
       entity_id: >
         {% if trigger.entity_id == 'input_select.marvin_status_dropdown' %}
           input_select.marvin_status_dropdown

--- a/automations/presence/extended_away.yaml
+++ b/automations/presence/extended_away.yaml
@@ -5,20 +5,20 @@ mode: single
 id: b0a446d1-8dfe-40c0-8ff9-e0df04c469db
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id: input_select.marvin_status_dropdown
     to: "Weg"
     for:
       hours: 24
-  - platform: state
+  - trigger: state
     entity_id: input_select.laura_status_dropdown
     to: "Weg"
     for:
       hours: 24
 
 action:
-  - service: input_select.select_option
-    data_template:
+  - action: input_select.select_option
+    data:
       entity_id: >
         {% if trigger.entity_id == 'input_select.marvin_status_dropdown' %}
           input_select.marvin_status_dropdown

--- a/automations/presence/home.yaml
+++ b/automations/presence/home.yaml
@@ -5,28 +5,28 @@ mode: single
 id: c68a2582-bdcc-48e3-a558-2ffdf4586522
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id: input_select.marvin_status_dropdown
     to: "Net thuis"
     for:
       minutes: 15
-  - platform: state
+  - trigger: state
     entity_id: input_select.laura_status_dropdown
     to: "Net thuis"
     for:
       minutes: 15
-  - platform: state
+  - trigger: state
     entity_id: input_select.marvin_status_dropdown
     from: "Net weg"
     to: "Net thuis"
-  - platform: state
+  - trigger: state
     entity_id: input_select.laura_status_dropdown
     from: "Net weg"
     to: "Net thuis"
 
 action:
-  - service: input_select.select_option
-    data_template:
+  - action: input_select.select_option
+    data:
       entity_id: >
         {% if trigger.entity_id == 'input_select.marvin_status_dropdown' %}
           input_select.marvin_status_dropdown

--- a/automations/presence/just_arrived.yaml
+++ b/automations/presence/just_arrived.yaml
@@ -5,18 +5,18 @@ mode: queued
 id: e72f181f-3840-472d-9529-db7a65ddd71b
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id: person.marvin
     from: "not_home"
     to: "home"
-  - platform: state
+  - trigger: state
     entity_id: person.laura
     from: "not_home"
     to: "home"
 
 action:
-  - service: input_select.select_option
-    data_template:
+  - action: input_select.select_option
+    data:
       entity_id: >
         {% if trigger.entity_id == 'person.marvin' %}
           input_select.marvin_status_dropdown

--- a/automations/presence/just_left.yaml
+++ b/automations/presence/just_left.yaml
@@ -5,18 +5,18 @@ mode: single
 id: 388b4902-87a3-4312-9f98-5a81fd720a9c
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id: person.marvin
     from: "home"
     to: "not_home"
-  - platform: state
+  - trigger: state
     entity_id: person.laura
     from: "home"
     to: "not_home"
 
 action:
-  - service: input_select.select_option
-    data_template:
+  - action: input_select.select_option
+    data:
       entity_id: >
         {% if trigger.entity_id == 'person.marvin' %}
           input_select.marvin_status_dropdown

--- a/automations/system/backup.yaml
+++ b/automations/system/backup.yaml
@@ -5,10 +5,10 @@ mode: single
 id: 9dc7b1ff-cd5a-4186-baa8-6aa3e788abac
 
 trigger:
-  platform: time
+  trigger: time
   at: "02:00:00"
 
 action:
-  - service: hassio.backup_full
-    data_template:
+  - action: hassio.backup_full
+    data:
       name: Automated Backup {{ now().strftime('%Y-%m-%d') }}

--- a/automations/system/events/scene_activated.yaml
+++ b/automations/system/events/scene_activated.yaml
@@ -5,7 +5,7 @@ mode: queued
 id: f6759b16-37b1-4190-bec1-51f7f4bd3128
 
 trigger:
-  - platform: event
+  - trigger: event
     event_type: call_service
     event_data:
       domain: scene
@@ -31,7 +31,7 @@ action:
             scene_category: "{{ scene_full.replace('scene.', '').split('_')[1] }}"
             scene_name: "{{ scene_full.replace('scene.', '').split('_')[2] }}"
 
-        - service: input_select.select_option
+        - action: input_select.select_option
           target:
             entity_id: >
               input_select.{{ scene_room }}_current_{{ scene_category }}_scene

--- a/automations/system/notifications/battery_empty.yaml
+++ b/automations/system/notifications/battery_empty.yaml
@@ -5,7 +5,7 @@ mode: queued
 id: 10d6cc7f-dabc-452d-976f-fdc683d7bbe7
 
 trigger:
-  - platform: numeric_state
+  - trigger: numeric_state
     entity_id:
       - sensor.pir_wc_battery_level
       - sensor.pir_master_bedroom_battery_level
@@ -30,7 +30,7 @@ trigger:
     id: "battery_dead"
     for:
       minutes: 30
-  - platform: numeric_state
+  - trigger: numeric_state
     entity_id:
       - sensor.pir_wc_battery_level
       - sensor.pir_master_bedroom_battery_level
@@ -56,7 +56,7 @@ trigger:
     id: "battery_low"
     for:
       minutes: 30
-  - platform: state
+  - trigger: state
     entity_id:
       - sensor.pir_wc_battery_level
       - sensor.pir_master_bedroom_battery_level
@@ -88,7 +88,7 @@ action:
           - condition: trigger
             id: "battery_dead"
         sequence:
-          - service: script.send_notification
+          - action: script.send_notification
             data:
               receivers:
                 - "marvin"
@@ -100,7 +100,7 @@ action:
           - condition: trigger
             id: "battery_unavailable"
         sequence:
-          - service: script.send_notification
+          - action: script.send_notification
             data:
               receivers:
                 - "marvin"
@@ -109,7 +109,7 @@ action:
                 {{ trigger.to_state.attributes.friendly_name }} is niet meer beschikbaar!
 
     default:
-      - service: script.send_notification
+      - action: script.send_notification
         data:
           receivers:
             - "marvin"

--- a/automations/system/notifications/doorbell.yaml
+++ b/automations/system/notifications/doorbell.yaml
@@ -17,7 +17,7 @@ action:
       - conditions:
           - "{{ event_id is string }}"
         sequence:
-          - service: script.send_notification
+          - action: script.send_notification
             data:
               receivers:
                 - "marvin"
@@ -28,7 +28,7 @@ action:
                     + event_id }}"
 
     default:
-      - service: script.send_notification
+      - action: script.send_notification
         data:
           receivers:
             - "marvin"

--- a/automations/system/notifications/garbage.yaml
+++ b/automations/system/notifications/garbage.yaml
@@ -6,7 +6,7 @@ mode: single
 id: 6488cf53-5292-4146-a44b-80ed0cf4ad7e
 
 trigger:
-  - platform: time
+  - trigger: time
     at: "18:00:00"
 
 condition:
@@ -15,7 +15,7 @@ condition:
     state: "1"
 
 action:
-  - service: script.send_notification
+  - action: script.send_notification
     data:
       receivers:
         - "marvin"

--- a/automations/system/notifications/picnic.yaml
+++ b/automations/system/notifications/picnic.yaml
@@ -5,11 +5,11 @@ mode: single
 id: 19f54bfb-fae0-46a2-b72c-75cbf467dfd2
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id:
       - sensor.picnic_next_delivery_eta_start
       - sensor.picnic_next_delivery_eta_end
-  - platform: time
+  - trigger: time
     at: "08:30:00"
 
 variables:
@@ -32,7 +32,7 @@ condition:
   - "{{ eta_start > as_timestamp(now()) }}"
 
 action:
-  - service: script.send_notification
+  - action: script.send_notification
     data:
       receivers:
         - "marvin"

--- a/automations/system/notifications/sauna_hot.yaml
+++ b/automations/system/notifications/sauna_hot.yaml
@@ -5,14 +5,14 @@ mode: single
 id: 1457f2ed-c313-4af4-9fdf-827596238980
 
 trigger:
-  - platform: numeric_state
+  - trigger: numeric_state
     entity_id: sensor.sauna_temperature
     above: 50
     for:
       minutes: 1
 
 action:
-  - service: script.send_notification
+  - action: script.send_notification
     data:
       receivers:
         - "marvin"

--- a/automations/system/notifications/sunscreen.yaml
+++ b/automations/system/notifications/sunscreen.yaml
@@ -5,7 +5,7 @@ mode: single
 id: b14e125e-baa1-4aef-b6cc-e4baf74cceab
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id: input_select.garden_current_cover_scene
 
 action:
@@ -15,7 +15,7 @@ action:
           - input_select.garden_current_cover_scene
         state: "sunblock"
     then:
-      - service: script.send_notification
+      - action: script.send_notification
         data:
           receivers:
             - "marvin"
@@ -29,7 +29,7 @@ action:
           - input_select.garden_current_cover_scene
         state: "open"
     then:
-      - service: script.send_notification
+      - action: script.send_notification
         data:
           receivers:
             - "marvin"

--- a/automations/system/notifications/vacuum_on.yaml
+++ b/automations/system/notifications/vacuum_on.yaml
@@ -5,12 +5,12 @@ mode: single
 id: 96522435-829f-419b-b3c0-adfafb88b209
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id: vacuum.norby
     to: "cleaning"
 
 action:
-  - service: script.send_notification
+  - action: script.send_notification
     data:
       receivers:
         - "marvin"

--- a/automations/system/notifications/washingmachine_done.yaml
+++ b/automations/system/notifications/washingmachine_done.yaml
@@ -5,13 +5,13 @@ mode: single
 id: 63b70abc-30bb-4db3-9bb9-eeccb8f2eed4
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id: binary_sensor.washing_machine
     from: "on"
     to: "off"
 
 action:
-  - service: script.send_notification
+  - action: script.send_notification
     data:
       receivers:
         - "marvin"

--- a/automations/system/notifications/washingmachine_overload.yaml
+++ b/automations/system/notifications/washingmachine_overload.yaml
@@ -5,11 +5,11 @@ mode: single
 id: c6c62798-8b28-4cf2-95db-0f090a60a1ff
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id: sensor.wasmachine_power_management_over_load_status
 
 action:
-  - service: script.send_notification
+  - action: script.send_notification
     data:
       receivers:
         - "marvin"

--- a/automations/system/recorder_purge.yaml
+++ b/automations/system/recorder_purge.yaml
@@ -9,8 +9,8 @@ id: e7a84c9a-90fb-4cbf-bbbe-9bfbdd7e6c19
 mode: single
 
 trigger:
-  - platform: time_pattern
+  - trigger: time_pattern
     minutes: 12
 
 action:
-  - service: recorder.purge
+  - action: recorder.purge

--- a/automations/system/recorder_repack.yaml
+++ b/automations/system/recorder_repack.yaml
@@ -8,7 +8,7 @@ id: d8309021-2ef7-4ee1-a837-4d81b962487b
 mode: single
 
 trigger:
-  - platform: time
+  - trigger: time
     at: "05:55"
 
 condition:
@@ -17,6 +17,6 @@ condition:
       - sun
 
 action:
-  - service: recorder.purge
+  - action: recorder.purge
     data:
       repack: true

--- a/blueprints/automation/motion_group_sonos.yaml
+++ b/blueprints/automation/motion_group_sonos.yaml
@@ -55,24 +55,24 @@ variables:
   group_on_tv: !input group_on_tv
 
 trigger:
-  - platform: state
+  - trigger: state
     entity_id: !input presence_entity
     to: "on"
 
-  - platform: state
+  - trigger: state
     entity_id: !input presence_entity
     to: "off"
     for:
       seconds: !input no_presence_wait
 
-  - platform: state
+  - trigger: state
     entity_id: !input sonos_source
     to: "playing"
 
-  - platform: homeassistant
+  - trigger: homeassistant
     event: start
 
-  - platform: event
+  - trigger: event
     event_type: automation_reloaded
 
 action:
@@ -99,7 +99,7 @@ action:
           # since this would cause a 1 sec silence
           - '{{ sonos_target not in state_attr(sonos_source, "group_members") }}'
         sequence:
-          - service: media_player.join
+          - action: media_player.join
             data:
               group_members:
                 - !input sonos_target
@@ -114,7 +114,7 @@ action:
             for:
               seconds: !input no_presence_wait
         sequence:
-          - service: media_player.unjoin
+          - action: media_player.unjoin
             data:
               entity_id: !input sonos_target
 

--- a/scripts/send_notification.yaml
+++ b/scripts/send_notification.yaml
@@ -50,7 +50,7 @@ sequence:
                 - "{{ receiver == 'marvin' }}"
                 - "{{ marvin_state in home_status }}"
               sequence:
-                - service: notify.mancave_tv
+                - action: notify.mancave_tv
                   continue_on_error: true
                   data:
                     message: "{{ emoji | default('') }} {{ message }}"
@@ -99,7 +99,7 @@ sequence:
                 (type == 'home_only' and marvin_state in home_status)
                 ) }}"
               sequence:
-                - service: notify.mobile_app_marvins_iphone_13_nieuw
+                - action: notify.mobile_app_marvins_iphone_13_nieuw
                   data:
                     message: "{{ emoji | default('') }} {{ message }}"
                     title: "{{ title }}"
@@ -113,7 +113,7 @@ sequence:
                 (type == 'home_only' and laura_state in home_status)
                 ) }}"
               sequence:
-                - service: notify.mobile_app_iphone_van_l_a
+                - action: notify.mobile_app_iphone_van_l_a
                   data:
                     message: "{{ emoji | default('') }} {{ message }}"
                     title: "{{ title }}"

--- a/scripts/turn_on_all_devices.yaml
+++ b/scripts/turn_on_all_devices.yaml
@@ -10,7 +10,7 @@ sequence:
           - "off"
         for: "00:01:00"
     then:
-      - service: media_player.media_play
+      - action: media_player.media_play
         data: {}
         target:
           entity_id: '{{ states("sensor.mass_media_entity") }}'


### PR DESCRIPTION
## Summary

Migrates the file-based automations (plus the related scripts and my own `motion_group_sonos` blueprint) to the modern Home Assistant YAML syntax introduced in [2024.8](https://developers.home-assistant.io/blog/2024/07/16/service-actions/) / [2024.10](https://www.home-assistant.io/blog/2024/10/02/release-202410/).

### Renames applied
| Old | New | Where |
|-----|-----|-------|
| `platform:` | `trigger:` | inside trigger definitions (incl. nested `wait_for_trigger` blocks) |
| `service:` | `action:` | inside action steps |
| `data_template:` | `data:` | templates are natively supported in `data:` |

These are **non-breaking, recommended** renames — the old syntax keeps working, and the UI automation editor already rewrites automations to this form on save.

### Scope & conventions
- **52 files** changed; pure key renames (237 insertions / 237 deletions, no structural changes).
- Top-level singular keys (`trigger:` / `condition:` / `action:`) are **kept** to match the convention already used in migrated files such as `automations/areas/bathroom/lights.yaml`.
- Scripts (`scripts/send_notification.yaml`, `scripts/turn_on_all_devices.yaml`) and my own `blueprints/automation/motion_group_sonos.yaml` are included since they share the same syntax. Third-party blueprints are left untouched.

### Intentionally left unchanged
- `service: turn_on` inside the `call_service` `event_data:` of `automations/system/events/scene_activated.yaml` — that key matches **event data**, it is not an action call, so it must stay `service:`.

## Verification
- All 91 touched/parsed files load as valid YAML.
- `yamllint` introduces **no new errors** (the handful of remaining warnings pre-exist on `master` and are in untouched lines).
- Verified there are no other `call_service` event triggers whose `event_data.service` would have been wrongly converted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)