### PR TITLE
Only close covers for heat when it's hotter outside than inside

### DIFF
--- a/automations/areas/livingroom/blinds_gardendoor.yaml
+++ b/automations/areas/livingroom/blinds_gardendoor.yaml
@@ -219,14 +219,6 @@ action:
       - alias: "Close the blinds a bit more a hot day"
         conditions:
           - or:
-              - and:
-                  - alias: Keep the heat out of the house on hot days
-                    condition: state
-                    entity_id:
-                      - binary_sensor.is_hot_day
-                    state: "on"
-                  # But only when it's hotter outside than inside
-                  - '{{ (states(temperature_entity) | float) <  (states("sensor.current_temperature") | float) }}'
               # - and:
               #     - alias: It's hot but we cannot close the sunscreen
               #       condition: state
@@ -237,6 +229,14 @@ action:
               #       entity_id:
               #         - binary_sensor.sun_should_close_south_blinds
               #       state: "on"
+              - and:
+                  - alias: Keep the heat out of the house on hot days
+                    condition: state
+                    entity_id:
+                      - binary_sensor.is_hot_day
+                    state: "on"
+                  # But only when it's hotter outside than inside
+                  - '{{ (states(temperature_entity) | float) <  (states("sensor.current_temperature") | float) }}'
         sequence:
           - *cover_sun
 

--- a/automations/areas/livingroom/blinds_gardendoor.yaml
+++ b/automations/areas/livingroom/blinds_gardendoor.yaml
@@ -87,6 +87,7 @@ trigger:
     id: "reset"
 
 variables:
+  temperature_entity: "sensor.livingroom_temperature"
   anchors:
     - &cover_closed
       alias: "Close the blinds"
@@ -218,11 +219,14 @@ action:
       - alias: "Close the blinds a bit more a hot day"
         conditions:
           - or:
-              - alias: Keep the heat out of the house on hot days
-                condition: state
-                entity_id:
-                  - binary_sensor.is_hot_day
-                state: "on"
+              - and:
+                  - alias: Keep the heat out of the house on hot days
+                    condition: state
+                    entity_id:
+                      - binary_sensor.is_hot_day
+                    state: "on"
+                  # But only when it's hotter outside than inside
+                  - '{{ (states(temperature_entity) | float) <  (states("sensor.current_temperature") | float) }}'
               # - and:
               #     - alias: It's hot but we cannot close the sunscreen
               #       condition: state

--- a/automations/areas/livingroom/blinds_livingroom.yaml
+++ b/automations/areas/livingroom/blinds_livingroom.yaml
@@ -72,6 +72,7 @@ trigger:
     id: "reset"
 
 variables:
+  temperature_entity: "sensor.livingroom_temperature"
   anchors:
     - &cover_closed
       alias: "Close the blinds"
@@ -161,11 +162,14 @@ action:
         conditions:
           - condition: or
             conditions:
-              - alias: Keep the heat out of the house on hot days
-                condition: state
-                entity_id:
-                  - binary_sensor.is_hot_day
-                state: "on"
+              - and:
+                  - alias: Keep the heat out of the house on hot days
+                    condition: state
+                    entity_id:
+                      - binary_sensor.is_hot_day
+                    state: "on"
+                  # But only when it's hotter outside than inside
+                  - '{{ (states(temperature_entity) | float) <  (states("sensor.current_temperature") | float) }}'
               # - and:
               #     - alias: It's hot but we cannot close the sunscreen
               #       condition: state

--- a/automations/areas/master_bedroom/curtains.yaml
+++ b/automations/areas/master_bedroom/curtains.yaml
@@ -42,6 +42,7 @@ trigger:
     id: awake
 
 variables:
+  temperature_entity: "sensor.pir_master_bedroom_temperature"
   anchors:
     - &close
       alias: "Open the curtains"
@@ -81,6 +82,8 @@ action:
             entity_id:
               - binary_sensor.is_hot_day
             state: "on"
+          # But only when it's hotter outside than inside
+          - '{{ (states(temperature_entity) | float) <  (states("sensor.current_temperature") | float) }}'
         sequence:
           - *close
 


### PR DESCRIPTION
## What

Adds a temperature guard to the cover automations that were still closing purely on `binary_sensor.is_hot_day`, so they only close to keep heat out when the room is actually cooler than outside:

- **Living room blinds** — `automations/areas/livingroom/blinds_livingroom.yaml`
- **Garden door blinds** — `automations/areas/livingroom/blinds_gardendoor.yaml`
- **Master bedroom curtains** — `automations/areas/master_bedroom/curtains.yaml`

Previously these closed whenever `is_hot_day` was `on`. On a hot day where the room had already cooled below the outside temperature, that just darkened the room without keeping any extra heat out.

## How

Each automation's "hot day" branch now also requires the room to be cooler than outside:

```yaml
- '{{ (states(temperature_entity) | float) < (states("sensor.current_temperature") | float) }}'
```

`temperature_entity` per area:
- Living room & garden door → `sensor.livingroom_temperature`
- Master bedroom curtains → `sensor.pir_master_bedroom_temperature`

Outside temperature is `sensor.current_temperature`.

This mirrors the guard already present in the **mancave** (`automations/areas/mancave/blinds.yaml`) and **master bedroom blinds** (`automations/areas/master_bedroom/blinds.yaml`) automations — so all the south-facing covers now behave consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)