### PR TITLE
Mancave: label-driven presence aggregate + purpose-specific occupancy triggers

### DIFF
--- a/automations/areas/mancave/lights.yaml
+++ b/automations/areas/mancave/lights.yaml
@@ -10,9 +10,9 @@ variables:
   anchors:
     - &condition_is_presence_detected
       alias: "Check if someone is in the mancave"
-      condition: state
-      entity_id: binary_sensor.presence_mancave
-      state: "on"
+      condition: occupancy.is_detected
+      target:
+        entity_id: binary_sensor.presence_mancave
 
     - &condition_is_dark
       alias: "Check if it's dark enough to turn on the light"
@@ -78,15 +78,15 @@ trigger:
   - trigger: event
     event_type: automation_reloaded
 
-  - trigger: state
-    entity_id: binary_sensor.presence_mancave
-    to: "on"
+  - trigger: occupancy.detected
+    target:
+      entity_id: binary_sensor.presence_mancave
 
-  - trigger: state
-    entity_id: binary_sensor.presence_mancave
-    to: "off"
-    for:
-      seconds: 300
+  - trigger: occupancy.cleared
+    target:
+      entity_id: binary_sensor.presence_mancave
+    options:
+      for: "00:05:00"
 
   - trigger: state
     entity_id: input_select.current_light_schedule

--- a/automations/areas/mancave/room_mode_staleness.yaml
+++ b/automations/areas/mancave/room_mode_staleness.yaml
@@ -22,11 +22,11 @@ action:
             state: "Slaap"
           - condition: time
             after: "10:00:00"
-          - condition: state
-            entity_id: binary_sensor.presence_mancave
-            state: "off"
-            for:
-              minutes: 30
+          - condition: occupancy.is_not_detected
+            target:
+              entity_id: binary_sensor.presence_mancave
+            options:
+              for: "00:30:00"
         sequence:
           - <<: *select_mode
             data:

--- a/automations/areas/mancave/speakers_set_volume.yaml
+++ b/automations/areas/mancave/speakers_set_volume.yaml
@@ -29,15 +29,15 @@ triggers:
     entity_id:
       - input_select.mancave_room_mode
 
-  - trigger: state
-    entity_id: binary_sensor.presence_mancave
-    to: "on"
+  - trigger: occupancy.detected
+    target:
+      entity_id: binary_sensor.presence_mancave
 
-  - trigger: state
-    entity_id: binary_sensor.presence_mancave
-    to: "off"
-    for:
-      seconds: 300
+  - trigger: occupancy.cleared
+    target:
+      entity_id: binary_sensor.presence_mancave
+    options:
+      for: "00:05:00"
 
 conditions:
   - alias: Only control the volume when we are automating the music
@@ -64,10 +64,9 @@ actions:
   - choose:
       - conditions:
           - or:
-              - condition: state
-                entity_id:
-                  - binary_sensor.presence_mancave
-                state: 'off'
+              - condition: occupancy.is_not_detected
+                target:
+                  entity_id: binary_sensor.presence_mancave
               - condition: state
                 entity_id:
                   - input_select.mancave_room_mode

--- a/entities/templates/binary_sensors/presence/presence_mancave.yaml
+++ b/entities/templates/binary_sensors/presence/presence_mancave.yaml
@@ -2,12 +2,18 @@
 binary_sensor:
   - name: presence_mancave
     unique_id: 1dc29348-5085-410a-9e76-0b67d26a220d
+    device_class: occupancy
+    # Motion/occupancy membership is label-driven: any sensor in the Mancave area
+    # carrying the 'included in automations' label counts. The TV, Apple Watch and
+    # door pulse cannot be expressed as a target, so they stay explicit.
     state: >
-      {{ is_state("binary_sensor.pir_mancave", "on")
-          or is_state("binary_sensor.presence_mancave_door", "on")
-          or is_state("media_player.mancave_tv", "on")
-          or (
-            is_state("sensor.apple_watch_marvin", "Mancave")
-            and states("sensor.apple_watch_marvin_distance") | int < 7
-          )
-      }}
+      {{ expand(area_entities("mancave"))
+           | selectattr("attributes.device_class", "in", ["motion", "occupancy"])
+           | selectattr("entity_id", "in", label_entities("included_in_automations"))
+           | selectattr("state", "eq", "on") | list | count > 0
+         or is_state("binary_sensor.presence_mancave_door", "on")
+         or is_state("media_player.mancave_tv", "on")
+         or (
+           is_state("sensor.apple_watch_marvin", "Mancave")
+           and states("sensor.apple_watch_marvin_distance") | int < 7
+         ) }}

--- a/entities/templates/binary_sensors/presence/presence_mancave_door.yaml
+++ b/entities/templates/binary_sensors/presence/presence_mancave_door.yaml
@@ -3,7 +3,7 @@
 # It triggers presence for 10sec, so that presence is not constantly
 # detected when someone does not close the door
 trigger:
-  - platform: state
+  - trigger: state
     entity_id: binary_sensor.mancave_door_open
     to: "on"
 


### PR DESCRIPTION
Pilots the Home Assistant 2026.7 [purpose-specific triggers](https://rc.home-assistant.io/blog/2026/06/24/release-20267/) in the **Mancave** (experimental room).

## Approach

`binary_sensor.presence_mancave` stays as the single fused presence signal — it has to, because it combines things a trigger/selector target *cannot* reach (TV on, Apple Watch in range, door pulse). What changes is that its **motion/occupancy membership becomes label-driven** instead of hard-coded:

```
area:mancave  ∩  label:included_in_automations  ∩  device_class:(motion|occupancy)
```

Add+label another PIR/mmWave in the room later and it auto-joins — no template edit. Junk sensors (a future camera's motion, a vacuum, etc.) are ignored unless explicitly labeled.

## Changes

| File | What |
|------|------|
| `entities/.../presence/presence_mancave.yaml` | Aggregate → area+label selector; TV/Watch/door kept as explicit OR; `device_class: occupancy` |
| `automations/areas/mancave/lights.yaml` | Presence triggers → `occupancy.detected` / `occupancy.cleared` (5 m); condition → `occupancy.is_detected` |
| `automations/areas/mancave/speakers_set_volume.yaml` | Same trigger swap; "presence off" → `occupancy.is_not_detected` |
| `automations/areas/mancave/room_mode_staleness.yaml` | "off for 30 min" → `occupancy.is_not_detected` + `options.for: "00:30:00"` |
| `entities/.../presence/presence_mancave_door.yaml` | Leftover `platform:` → `trigger:` |

## ⚠️ Required deploy steps (not all expressible in YAML)

1. **Labels — already applied to the live instance.** All old thematic labels were deleted and a single `included in automations` label created + assigned to `binary_sensor.pir_mancave`.
2. **🔴 Set the `device_class` override in the UI (REQUIRED, done manually by me).** `presence_mancave` carries a registry `device_class` override of `motion` that masks the YAML. Until it's set to **Occupancy**, the `occupancy.*` triggers won't bind. **Settings → Devices & Services → Entities → `presence_mancave` → ⚙️ → "Show as" → Occupancy.**
3. **Reload Template Entities + Reload Automations** (or restart).

Steps 1–2 must land together with this merge: until `pir_mancave` is labeled and the class is occupancy, presence falls back to the TV/Watch/door clauses only.

## Notes

- Trigger/condition names are from the 2026.7 docs — worth a sanity check in the automation editor since it's beta.
- `device_class: occupancy` is also set in the template YAML so the entity is code-defined once the UI override matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)