### PR TITLE
Add missing telegram_marvin_chat_id to fake secrets (fix HA CI)

### DIFF
--- a/secrets.fake.yaml
+++ b/secrets.fake.yaml
@@ -52,3 +52,4 @@ velux_password: abcdef12345
 telegram_bot_token: "0123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHI"
 telegram_allowed_chat_ids:
   - 0123456789
+telegram_marvin_chat_id: 123456789


### PR DESCRIPTION
## What

Fixes the Home Assistant **Configuration Check** CI failure caused by an undefined secret for the telegram notifier.

`entities/notify/telegram_marvin.yaml` references `!secret telegram_marvin_chat_id`, but that key was missing from `secrets.fake.yaml` — which is exactly the file the CI job feeds to the config check:

```yaml
# .github/workflows/home-assistant.yml
- uses: frenck/action-home-assistant@v1.4
  with:
    secrets: ./secrets.fake.yaml
```

So `hass --script check_config` failed resolving the secret for the telegram notify platform.

## Fix

Add a fake `telegram_marvin_chat_id` to `secrets.fake.yaml` (plain integer, matching what the telegram notify `chat_id` expects).

## Verification

- `telegram_marvin_chat_id` now resolves; a scan of all `!secret` references used by the HA config (`entities/`, `integrations/`, `automations/`) shows **no remaining undefined secrets**.
- `yamllint secrets.fake.yaml` passes.

> Note: there are four other `!secret` keys not in this file (`wifi_ssid`, `wifi_password`, `ota_pwd`, `api_encryption_key`), but those are referenced **only** by ESPHome configs under `esphome/`, which the HA config check does not process — so they don't affect this CI job and are intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)