### PR TITLE
Serialize speaker group changes and start playback on first join

### DIFF
--- a/automations/areas/livingroom/group_speakers.yaml
+++ b/automations/areas/livingroom/group_speakers.yaml
@@ -63,20 +63,18 @@ variables:
         }}
 
     - &group
-      alias: "Start playing music on the master group"
-      action: media_player.join
-      target:
-        entity_id: "{{ mass_entity }}"
+      alias: "Join the speaker to the master group (serialized via script)"
+      action: script.speaker_group
       data:
-        group_members:
-          - media_player.mass_woonkamer_wiim
+        operation: join
+        target_player: media_player.mass_woonkamer_wiim
 
     - &ungroup
-      alias: "Ensure the media player is on"
-      action: media_player.unjoin
-      data: {}
-      target:
-        entity_id: media_player.mass_woonkamer_wiim
+      alias: "Remove the speaker from the master group (serialized via script)"
+      action: script.speaker_group
+      data:
+        operation: unjoin
+        target_player: media_player.mass_woonkamer_wiim
 
 conditions:
   - condition: state

--- a/automations/areas/mancave/group_speakers.yaml
+++ b/automations/areas/mancave/group_speakers.yaml
@@ -85,13 +85,11 @@ action:
                       - media_player.mancave_wiim_amp
                     state: playing
             then:
-              - alias: Turn the child media player on
-                action: media_player.join
-                target:
-                  entity_id: '{{ mass_entity }}'
+              - alias: "Join the speaker to the master group (serialized via script)"
+                action: script.speaker_group
                 data:
-                  group_members:
-                    - media_player.mass_mancave_wiim_amp
+                  operation: join
+                  target_player: media_player.mass_mancave_wiim_amp
 
       - conditions:
           - condition: state
@@ -107,11 +105,11 @@ action:
                 state: "off"
           - *condition_in_group
         sequence:
-          - alias: Turn the child media player off
-            action: media_player.unjoin
-            data: {}
-            target:
-              entity_id: media_player.mass_mancave_wiim_amp
+          - alias: "Remove the speaker from the master group (serialized via script)"
+            action: script.speaker_group
+            data:
+              operation: unjoin
+              target_player: media_player.mass_mancave_wiim_amp
 
       - conditions:
           - not:
@@ -129,10 +127,10 @@ action:
                       - *condition_tv_game
           - *condition_in_group
         sequence:
-          - alias: Turn the child media player off
-            action: media_player.unjoin
-            data: {}
-            target:
-              entity_id: media_player.mass_mancave_wiim_amp
+          - alias: "Remove the speaker from the master group (serialized via script)"
+            action: script.speaker_group
+            data:
+              operation: unjoin
+              target_player: media_player.mass_mancave_wiim_amp
 
     default: []

--- a/blueprints/automation/group_speakers.yaml
+++ b/blueprints/automation/group_speakers.yaml
@@ -52,20 +52,18 @@ variables:
         }}
 
     - &group
-      alias: "Ungroup the speaker from the target"
-      action: media_player.join
-      target:
-        entity_id: media_player.huis
+      alias: "Join the speaker to the master group (serialized via script)"
+      action: script.speaker_group
       data:
-        group_members:
-          - !input target_media_player
+        operation: join
+        target_player: !input target_media_player
 
     - &ungroup
-      alias: "Group the speaker to the target"
-      action: media_player.unjoin
-      data: {}
-      target:
-        entity_id: !input target_media_player
+      alias: "Remove the speaker from the master group (serialized via script)"
+      action: script.speaker_group
+      data:
+        operation: unjoin
+        target_player: !input target_media_player
 
 trigger:
   - trigger: state
@@ -97,7 +95,6 @@ action:
               - !input presence_entity
               - input_boolean.setting_automatic_music
             state: "on"
-          - "{{ is_state(mass_entity, 'playing') }}"
           - condition: and
             conditions: !input custom_conditions
           - not:

--- a/scripts/speaker_group.yaml
+++ b/scripts/speaker_group.yaml
@@ -1,0 +1,75 @@
+---
+alias: speaker_group
+description: >
+  Join or unjoin a speaker to/from the Music Assistant master group.
+  All group changes run through this single queued script, so rapid
+  join/unjoin commands from different automations are serialized and
+  no longer hit Music Assistant within milliseconds of each other
+  (which caused dissolve/reform races and stopped playback).
+  When the first speaker joins a group that is not playing, playback
+  is started automatically.
+mode: queued
+max: 25
+
+fields:
+  operation:
+    description: Either 'join' or 'unjoin'
+  target_player:
+    description: The mass media player entity to add/remove
+
+variables:
+  mass_entity: '{{ states("sensor.mass_media_entity") }}'
+
+sequence:
+  - choose:
+      - conditions: "{{ operation == 'join' }}"
+        sequence:
+          - alias: "Join the speaker to the master group"
+            action: media_player.join
+            target:
+              entity_id: "{{ mass_entity }}"
+            data:
+              group_members:
+                - "{{ target_player }}"
+
+          - alias: "Wait until MA confirms the member was added"
+            wait_template: >-
+              {{ target_player in (state_attr(mass_entity, 'group_members') or []) }}
+            timeout:
+              seconds: 10
+
+          - alias: "First member joined a silent group: start playback"
+            if:
+              - "{{ not is_state(mass_entity, 'playing') }}"
+              - condition: state
+                entity_id: input_boolean.setting_automatic_music
+                state: "on"
+              - condition: time
+                after: "07:00:00"
+                before: "21:30:00"
+            then:
+              - if:
+                  - '{{ is_state(mass_entity, "off") }}'
+                then:
+                  - action: media_player.turn_on
+                    data: {}
+                    target:
+                      entity_id: "{{ mass_entity }}"
+              - action: media_player.media_play
+                data: {}
+                target:
+                  entity_id: "{{ mass_entity }}"
+
+      - conditions: "{{ operation == 'unjoin' }}"
+        sequence:
+          - alias: "Remove the speaker from the master group"
+            action: media_player.unjoin
+            data: {}
+            target:
+              entity_id: "{{ target_player }}"
+
+          - alias: "Wait until MA confirms the member was removed"
+            wait_template: >-
+              {{ target_player not in (state_attr(mass_entity, 'group_members') or []) }}
+            timeout:
+              seconds: 10


### PR DESCRIPTION
## Problem
The livingroom, mancave and kitchen `group_speakers` automations each call `media_player.join`/`unjoin` independently. Each automation is queued on its own, but there is no serialization *across* automations, so rapid presence/TV changes fire unjoins into Music Assistant within milliseconds. This triggers dissolve/reform races in the WiiM sync group and music stops (see music-assistant/server#4644 for the MA-side fix).

Also, the blueprint's join branch required the group to already be `playing`, so the first speaker to join never started playback.

## Changes
- New `scripts/speaker_group.yaml`: single queued script that performs all join/unjoin operations, waits for MA to confirm the membership change, and starts playback when the first speaker joins a silent group (respecting `setting_automatic_music` and the 07:00–21:30 window from `play_music`)
- `blueprints/automation/group_speakers.yaml`: join/unjoin now go through the script; removed the `is_state(mass_entity, 'playing')` join precondition so the first join initiates playback
- `automations/areas/livingroom/group_speakers.yaml` and `automations/areas/mancave/group_speakers.yaml`: join/unjoin now go through the script