### PR TITLE
Prevent bedroom curtains from opening on redundant close command

### DIFF
--- a/automations/areas/master_bedroom/curtains.yaml
+++ b/automations/areas/master_bedroom/curtains.yaml
@@ -48,8 +48,11 @@ variables:
       alias: "Close the curtains"
       # Forest Shuttle S/L quirk: a close command while already closed makes it open
       if:
-        - condition: template
-          value_template: "{{ not is_state('cover.master_bedroom_curtains', 'closed') }}"
+        - condition: not
+          conditions:
+            - condition: state
+              entity_id: cover.master_bedroom_curtains
+              state: "closed"
       then:
         - action: cover.close_cover
           target:
@@ -88,7 +91,10 @@ action:
               - binary_sensor.is_hot_day
             state: "on"
           # But only when it's hotter outside than inside
-          - '{{ (states(temperature_entity) | float) <  (states("sensor.current_temperature") | float) }}'
+          - condition: template
+            value_template: >-
+              {{ (states(temperature_entity) | float)
+                 < (states("sensor.current_temperature") | float) }}
         sequence:
           - *close
 

--- a/automations/areas/master_bedroom/curtains.yaml
+++ b/automations/areas/master_bedroom/curtains.yaml
@@ -45,10 +45,15 @@ variables:
   temperature_entity: "sensor.pir_master_bedroom_temperature"
   anchors:
     - &close
-      alias: "Open the curtains"
-      action: cover.close_cover
-      target:
-        entity_id: cover.master_bedroom_curtains
+      alias: "Close the curtains"
+      # Forest Shuttle S/L quirk: a close command while already closed makes it open
+      if:
+        - condition: template
+          value_template: "{{ not is_state('cover.master_bedroom_curtains', 'closed') }}"
+      then:
+        - action: cover.close_cover
+          target:
+            entity_id: cover.master_bedroom_curtains
 
     - &open
       alias: "Open the curtains"


### PR DESCRIPTION
## Problem

The Forest Shuttle S/L curtain motor (`cover.master_bedroom_curtains`) physically opens when it receives a `close_cover` command while already fully closed. This happened at night when the room mode changed and the automation sent a redundant close command (verified via automation traces: device reported `open` 5s later with no HA context).

## Changes

- Guard the `&close` anchor so `cover.close_cover` is only sent when the cover is not already closed
- Fix copy-paste bug: the `&close` anchor was aliased "Open the curtains", renamed to "Close the curtains"